### PR TITLE
Add command creation callback

### DIFF
--- a/Internal/Scripts/Views/LogConsole.cs
+++ b/Internal/Scripts/Views/LogConsole.cs
@@ -26,6 +26,7 @@ namespace MobileConsole
 		private static event Callback OnAllSubViewClosed;
         private static event Callback OnShareAllLogRequest;
 
+		public static event Action<Command> OnCommandCreated;
 		public delegate void EventCommandsCreated(ReadOnlyCollection<Command> commands);
 		public static event EventCommandsCreated OnCommandsCreated;
 		private static bool _hasCommandsCreated = false;
@@ -128,6 +129,8 @@ namespace MobileConsole
 				if (attribute != null)
 				{
 					Command command = (Command)Activator.CreateInstance(commandType);
+					OnCommandCreated?.Invoke(command);
+					
 					command.CacheVariableInfos(commandType);
 					command.CacheCustomButtonInfos(commandType, typeof(ButtonAttribute));
 					command.info.CopyData(attribute, commandType);

--- a/Internal/Scripts/Views/LogConsole.cs
+++ b/Internal/Scripts/Views/LogConsole.cs
@@ -159,6 +159,8 @@ namespace MobileConsole
 				if (attribute != null)
 				{
 					Command command = (Command)Activator.CreateInstance(commandType);
+					OnCommandCreated?.Invoke(command);
+					
 					command.CacheVariableInfos(commandType);
 					command.info.CopyData(attribute, commandType);
 


### PR DESCRIPTION
There is a problem with the initialization order when using **dependency injection** (in my case, Zenject). The problem is that the `OnCommandsCreated` callback is called too late for Zenject. Some internal logic is executed before it (namely, the command variable change callbacks registered to the `OnValueChanged` attribute), which may require dependencies that Zenject should have provided. This causes a `NullReferenceException`.

Initialization order of command: 
1. Initializing of default values of variables.
2. Loading variables values from PlayerPrefs if they exist.
3. Changing variables values followed by a callback. This may cause a `NullReferenceException` because
the command dependencies have not yet been injected.
4. Injecting dependencies by Zenject (too late).

So I created the `OnCommandCreated` callback, which is invoked per command before any internal callback.

Also, I recommend renaming the previous `OnCommandsCreated` to `OnCommandsInitialized` to distinguish between creation and initialization. Same with the `HasCommandsCreated` property (to `HasCommandsInitialized`). I didn't do it because it is breaking changes, and I don't know your package update pipeline.

